### PR TITLE
Avoid ignoring errors in get_latest_resources

### DIFF
--- a/src/runtime/resource/resource_partition.rs
+++ b/src/runtime/resource/resource_partition.rs
@@ -194,11 +194,9 @@ impl ResourcePartition {
         self.packages.len().saturating_sub(1)
     }
 
-    pub fn get_latest_resources(&self) -> Vec<(&ResourceInfo, &PatchId)> {
-        self.resources.iter().flat_map(|(rrid, idx)| {
-            if let Ok(info) = self.get_resource_info_from(rrid, idx){
-                Some((info, idx))
-            }else {None}
+    pub fn get_latest_resources(&self) -> Result<Vec<(&ResourceInfo, &PatchId)>> {
+        self.resources.iter().map(|(rrid, idx)| {
+            Ok((self.get_resource_info_from(rrid, idx)?, idx))
         }).collect()
     }
 


### PR DESCRIPTION
You can collect an iterator of Results into a single Result that fails when any of them fail.