### PR TITLE
fix: pdef resource path regex missing valid matches, ResourceID::from_str replacing parts of the path

### DIFF
--- a/src/misc/resource_id.rs
+++ b/src/misc/resource_id.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-static CONSOLE_TAG: &str = "pc";
+static PLATFORM_TAG: &str = "pc";
 
 #[derive(Error, Debug)]
 pub enum ResourceIDError {
@@ -44,7 +44,7 @@ impl FromStr for ResourceID {
         };
 
         Ok(Self {
-            uri: rid.uri.replace(format!("{CONSOLE_TAG}_").as_str(), ""),
+            uri: rid.uri.replace(format!("].{PLATFORM_TAG}_").as_str(), "]."),
         })
     }
 }
@@ -266,6 +266,20 @@ impl ResourceID {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn test_creation() -> Result<(), ResourceIDError> {
+        let resource_id = ResourceID::from_str(
+            "[assembly:/_PRO/Scenes/Missions/thefacility/vr_tutorial_pc_graduation.brick].entitytype"
+        )?;
+        assert_eq!(resource_id.resource_path(), "[assembly:/_pro/scenes/missions/thefacility/vr_tutorial_pc_graduation.brick].pc_entitytype");
+
+        let resource_id = ResourceID::from_str(
+            "[assembly:/_PRO/Scenes/Missions/thefacility/vr_tutorial_pc_graduation.brick].pc_entitytype"
+        )?;
+        assert_eq!(resource_id.uri, "[assembly:/_pro/scenes/missions/thefacility/vr_tutorial_pc_graduation.brick].entitytype");
+        Ok(())
+    }
+
     #[test]
     fn test_parameters() -> Result<(), ResourceIDError> {
         let mut resource_id = ResourceID::from_str(

--- a/src/resource/pdefs/h2016_parser.rs
+++ b/src/resource/pdefs/h2016_parser.rs
@@ -1,7 +1,7 @@
 use crate::encryption::xtea::Xtea;
 use crate::misc::resource_id::ResourceID;
 use crate::resource::pdefs::{
-    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType,
+    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType, RESOURCE_PATH_REGEX,
 };
 use lazy_regex::regex;
 use std::str::FromStr;
@@ -24,8 +24,6 @@ impl PackageDefinitionParser for H2016Parser {
         let partition_regex = regex!(r"#([A-z]+) patchlevel=([0-9]+)");
 
         let langdlc_regex = regex!(r"#langdlc ([A-z]+)");
-
-        let resource_path_regex = regex!(r"(\[[a-z]+:/.+?]).([a-z]+)");
 
         for line in deciphered_data.lines() {
             let trimmed_line = line.trim();
@@ -84,8 +82,8 @@ impl PackageDefinitionParser for H2016Parser {
                         partitions.append(&mut lang_partitions);
                     }
                 }
-                line if resource_path_regex.is_match(trimmed_line) => {
-                    if let Some(m) = resource_path_regex.captures_iter(line).next() {
+                line if RESOURCE_PATH_REGEX.is_match(trimmed_line) => {
+                    if let Some(m) = RESOURCE_PATH_REGEX.captures_iter(line).next() {
                         if let Some(current_partition) = partitions.last_mut() {
                             if let Ok(rid) =
                                 ResourceID::from_str(format!("{}.{}", &m[1], &m[2]).as_str())

--- a/src/resource/pdefs/hm2_parser.rs
+++ b/src/resource/pdefs/hm2_parser.rs
@@ -1,7 +1,7 @@
 use crate::encryption::xtea::Xtea;
 use crate::misc::resource_id::ResourceID;
 use crate::resource::pdefs::{
-    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType,
+    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType, RESOURCE_PATH_REGEX,
 };
 use lazy_regex::regex;
 use std::str::FromStr;
@@ -22,8 +22,6 @@ impl PackageDefinitionParser for HM2Parser {
         let mut previous_lines: [&str; 2] = ["", ""];
 
         let partition_regex = regex!(r"@([A-z]+) patchlevel=([0-9]+)");
-
-        let resource_path_regex = regex!(r"(\[[a-z]+:/.+?]).([a-z]+)");
 
         for line in deciphered_data.lines() {
             let trimmed_line = line.trim();
@@ -53,8 +51,8 @@ impl PackageDefinitionParser for HM2Parser {
                         });
                     }
                 }
-                line if resource_path_regex.is_match(trimmed_line) => {
-                    if let Some(m) = resource_path_regex.captures_iter(line).next() {
+                line if RESOURCE_PATH_REGEX.is_match(trimmed_line) => {
+                    if let Some(m) = RESOURCE_PATH_REGEX.captures_iter(line).next() {
                         if let Some(current_partition) = partitions.last_mut() {
                             if let Ok(rid) =
                                 ResourceID::from_str(format!("{}.{}", &m[1], &m[2]).as_str())

--- a/src/resource/pdefs/hm3_parser.rs
+++ b/src/resource/pdefs/hm3_parser.rs
@@ -1,7 +1,7 @@
 use crate::encryption::xtea::Xtea;
 use crate::misc::resource_id::ResourceID;
 use crate::resource::pdefs::{
-    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType,
+    PackageDefinitionError, PackageDefinitionParser, PartitionId, PartitionInfo, PartitionType, RESOURCE_PATH_REGEX,
 };
 use lazy_regex::regex;
 use std::str::FromStr;
@@ -23,7 +23,6 @@ impl PackageDefinitionParser for HM3Parser {
         //define the regex
         let partition_regex =
             regex!(r"@partition name=(.+?) parent=(.+?) type=(.+?) patchlevel=(.\d*)");
-        let resource_path_regex = regex!(r"(\[[a-z]+:/.+?]).([a-z]+)");
 
         //try to match the regex on a per-line basis
         for line in deciphered_data.lines() {
@@ -44,8 +43,8 @@ impl PackageDefinitionParser for HM3Parser {
                         roots: vec![],
                     });
                 }
-            } else if resource_path_regex.is_match(line) {
-                if let Some(m) = resource_path_regex.captures_iter(line).next() {
+            } else if RESOURCE_PATH_REGEX.is_match(line) {
+                if let Some(m) = RESOURCE_PATH_REGEX.captures_iter(line).next() {
                     if let Some(current_partition) = partitions.last_mut() {
                         if let Ok(rid) =
                             ResourceID::from_str(format!("{}.{}", &m[1], &m[2]).as_str())

--- a/src/resource/pdefs/mod.rs
+++ b/src/resource/pdefs/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use glacier_ini::ini_file::IniFileError;
 use glacier_ini::IniFileSystem;
-use lazy_regex::regex;
+use lazy_regex::{Lazy, Regex, regex};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -19,6 +19,8 @@ use crate::{utils, WoaVersion};
 pub mod h2016_parser;
 pub mod hm2_parser;
 pub mod hm3_parser;
+
+const RESOURCE_PATH_REGEX: &Lazy<Regex> = regex!(r"(\[[A-z]+:/.+?]).([A-z]+)");
 
 #[derive(Debug, Error)]
 pub enum PackageDefinitionError {


### PR DESCRIPTION
As title.